### PR TITLE
Add link to external resource about A* algorithm

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,9 @@ The examples have been developed and tested with Python 3.5.1.
 - Quentin Lurkin
 - Alexis Nootens
 - Benoît Wéry
+
+## External Resources
+
+External resources that students can use to deepen their understanding of topics viewed during this course
+
+- [en] [Amit’s A* Pages - Game programming](http://theory.stanford.edu/~amitp/GameProgramming/AStarComparison.html) - Introduction to pathfinding with the A* algorithm


### PR DESCRIPTION
I have added an "external resources" section in the README to link to some interesting articles / posts about topics related to the course.

Currently, the only link I have added is to a page that explains the A\* algorithm in a simple and detailed way.
